### PR TITLE
⚡ Optimize ProgressContext with useMemo

### DIFF
--- a/src/contexts/ProgressContext.tsx
+++ b/src/contexts/ProgressContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState, useCallback, useMemo } from "react";
 import { getProgress, type Progress, updateProgress } from "@/utils/progress";
 
 type ProgressContextType = {
@@ -23,30 +23,33 @@ export const ProgressProvider = ({
 	const [isGameOver, setIsGameOver] = useState<boolean>(false);
 	const gameEndedRef = useRef<boolean>(false);
 
-	function handleUpdateProgress(win: boolean) {
+	const handleUpdateProgress = useCallback((win: boolean) => {
 		if (!gameEndedRef.current) {
 			const updated = updateProgress(win);
 			setProgress(updated);
 			gameEndedRef.current = true;
 		}
-	}
+	}, []);
 
-	function resetGame() {
+	const resetGame = useCallback(() => {
 		setIsGameOver(false);
 		gameEndedRef.current = false;
-	}
+	}, []);
+
+	const value = useMemo(
+		() => ({
+			progress,
+			setProgress,
+			updateProgress: handleUpdateProgress,
+			isGameOver,
+			setIsGameOver,
+			resetGame,
+		}),
+		[progress, isGameOver, handleUpdateProgress, resetGame],
+	);
 
 	return (
-		<ProgressContext.Provider
-			value={{
-				progress,
-				setProgress,
-				updateProgress: handleUpdateProgress,
-				isGameOver,
-				setIsGameOver,
-				resetGame,
-			}}
-		>
+		<ProgressContext.Provider value={value}>
 			{children}
 		</ProgressContext.Provider>
 	);

--- a/src/tests/ProgressContext.perf.test.tsx
+++ b/src/tests/ProgressContext.perf.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React, { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { ProgressProvider, useProgress } from "../contexts/ProgressContext";
+
+const renderCounter = { count: 0 };
+
+const TestConsumer = React.memo(() => {
+	useProgress();
+	renderCounter.count++;
+	return <div>Consumer</div>;
+});
+
+const TestParent = () => {
+	const [_count, setCount] = useState(0);
+	return (
+		<div>
+			<button type="button" onClick={() => setCount((c) => c + 1)}>
+				Force Render
+			</button>
+			<ProgressProvider>
+				<TestConsumer />
+			</ProgressProvider>
+		</div>
+	);
+};
+
+describe("ProgressContext Performance", () => {
+	it("does not re-render consumers when provider re-renders but value is unchanged", async () => {
+		renderCounter.count = 0;
+		const user = userEvent.setup();
+		render(<TestParent />);
+
+		// Initial render
+		expect(renderCounter.count).toBe(1);
+
+		// Force parent re-render
+		const button = screen.getByText("Force Render");
+		await user.click(button);
+
+		// Expectation: count should still be 1 if optimized.
+		// Currently it will be 2.
+		expect(renderCounter.count).toBe(1);
+	});
+});


### PR DESCRIPTION
💡 **What:** Memoized the `ProgressContext` value using `useMemo` and wrapped `handleUpdateProgress` and `resetGame` in `useCallback`.
🎯 **Why:** To prevent unnecessary re-renders of consuming components when the `ProgressProvider` itself re-renders but the underlying state (`progress`, `isGameOver`) has not changed. This ensures that stable references are passed down via context.
📊 **Measured Improvement:**
*   **Baseline:** Consumers re-rendered every time the provider's parent updated, even if context data was unchanged. (Verified count: 2)
*   **Optimized:** Consumers now only re-render when the actual context state changes. (Verified count: 1)
*   Added `src/tests/ProgressContext.perf.test.tsx` to verify this behavior and prevent regressions.

---
*PR created automatically by Jules for task [16109796628690044843](https://jules.google.com/task/16109796628690044843) started by @julioCoronetti*